### PR TITLE
Allow for a defined order instead of yolo

### DIFF
--- a/Context/ConfiguredContextProvider.php
+++ b/Context/ConfiguredContextProvider.php
@@ -69,7 +69,7 @@ class ConfiguredContextProvider
         $this->facetCollatorProvider = $facetCollatorProvider;
         $this->facetSortOrderProvider = $facetSortOrderProvider;
         $this->interceptorProvider = $interceptorProvider;
-        $this->decorators = new \SplQueue();
+        $this->decorators = new ContextDecoratorPriorityQueue();
     }
 
     /**
@@ -95,14 +95,16 @@ class ConfiguredContextProvider
     }
 
     /**
-     * Add a context decorator to be apply to any generated context. First decorators provided are applied first.
+     * Add a context decorator to be apply to any generated context.
      *
      * @param ContextDecoratorInterface $decorator
-     * @return self
+     * @param int                       $priority
+     *
+     * @return $this
      */
-    public function addDecorator(ContextDecoratorInterface $decorator)
+    public function addDecorator(ContextDecoratorInterface $decorator, $priority = 500)
     {
-        $this->decorators->enqueue($decorator);
+        $this->decorators->insert($decorator, $priority);
 
         return $this;
     }

--- a/Context/ConfiguredContextProvider.php
+++ b/Context/ConfiguredContextProvider.php
@@ -102,7 +102,7 @@ class ConfiguredContextProvider
      *
      * @return $this
      */
-    public function addDecorator(ContextDecoratorInterface $decorator, $priority = 500)
+    public function addDecorator(ContextDecoratorInterface $decorator, $priority = 0)
     {
         $this->decorators->insert($decorator, $priority);
 

--- a/Context/ContextDecoratorPriorityQueue.php
+++ b/Context/ContextDecoratorPriorityQueue.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Markup\NeedleBundle\Context;
+
+use SplPriorityQueue;
+
+/**
+ * Class ContextDecoratorPriorityQueue
+ *
+ * @package Markup\NeedleBundle\Context
+ */
+class ContextDecoratorPriorityQueue extends \SplPriorityQueue
+{
+    protected $queueOrder = PHP_INT_MAX;
+
+    /**
+     * @param mixed $datum
+     * @param mixed $priority
+     */
+    public function insert($datum, $priority)
+    {
+        if (is_int($priority)) {
+            $priority = [$priority, $this->queueOrder--];
+        }
+        parent::insert($datum, $priority);
+    }
+}

--- a/Tests/Context/ContextDecoratorPriorityQueueTest.php
+++ b/Tests/Context/ContextDecoratorPriorityQueueTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Markup\NeedleBundle\Tests\Context;
+
+use Markup\NeedleBundle\Context\ContextDecoratorPriorityQueue;
+
+class ContextDecoratorPriorityQueueTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAddingWithoutOrder()
+    {
+        $queue = new ContextDecoratorPriorityQueue();
+        $queue->insert('first', 100);
+        $queue->insert('second', 100);
+        $queue->insert('third', 100);
+        $queue->insert('fourth', 100);
+
+        $this->assertEquals('first|second|third|fourth', $this->implodeQueue($queue));
+    }
+
+    public function testOrder()
+    {
+        $queue = new ContextDecoratorPriorityQueue();
+        $queue->insert('fourth', -44);
+        $queue->insert('second', 100);
+        $queue->insert('first', 150);
+        $queue->insert('third', 99);
+
+        $this->assertEquals('first|second|third|fourth', $this->implodeQueue($queue));
+    }
+
+    private function implodeQueue(ContextDecoratorPriorityQueue $queue)
+    {
+        return implode('|', iterator_to_array($queue));
+    }
+
+}


### PR DESCRIPTION
I think its the right thing to do to allow a defined ordering, although I think also it would be good if as decorators are added they push a value onto an array of the class name / interface onto something to allow for a `instanceof` like operation to be made against the final result?

Allowing me to ensure my decorator to be the final one will solve my issue right now but long term maybe something like the above is better? @shieldo thoughts? Id like to just get this through now if possible though.