### PR TITLE
feat: expose original select query from resolved query

### DIFF
--- a/Query/ResolvedSelectQuery.php
+++ b/Query/ResolvedSelectQuery.php
@@ -274,6 +274,16 @@ class ResolvedSelectQuery implements ResolvedSelectQueryInterface
     }
 
     /**
+     * Gets the original select query prior to resolution, for read-only access.
+     *
+     * @return SelectQueryInterface
+     */
+    public function getOriginalSelectQuery()
+    {
+        return $this->getSelectQuery();
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getRecord()

--- a/Query/ResolvedSelectQueryInterface.php
+++ b/Query/ResolvedSelectQueryInterface.php
@@ -58,6 +58,13 @@ interface ResolvedSelectQueryInterface extends SelectQueryInterface
     public function shouldUseFacetValuesForRecordedQuery();
 
     /**
+     * Gets the original select query prior to resolution, for read-only access.
+     *
+     * @return SelectQueryInterface
+     */
+    public function getOriginalSelectQuery();
+
+    /**
      * If the internal query is an instance of RecordableSelectQueryInterface and has a record, returns SelectQueryInterface
      * otherwise null
      *

--- a/Tests/Query/ResolvedSelectQueryInterfaceTest.php
+++ b/Tests/Query/ResolvedSelectQueryInterfaceTest.php
@@ -32,6 +32,7 @@ class ResolvedSelectQueryInterfaceTest extends \PHPUnit_Framework_TestCase
             'getWhetherFacetIgnoresCurrentFilters',
             'getBoostQueryFields',
             'shouldUseFacetValuesForRecordedQuery',
+            'getOriginalSelectQuery',
             'getRecord',
             'getGroupingField',
             'getGroupingSortCollection'

--- a/Tests/Query/ResolvedSelectQueryTest.php
+++ b/Tests/Query/ResolvedSelectQueryTest.php
@@ -87,4 +87,9 @@ class ResolvedSelectQueryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(3, count($query->getFilterQueries()));
     }
+
+    public function testGetOriginalSelectQuery()
+    {
+        $this->assertSame($this->query, (new ResolvedSelectQuery($this->query))->getOriginalSelectQuery());
+    }
 }


### PR DESCRIPTION
ping @calumbrodie - this enables access to the original query from the resolved, as it can be useful to have access to that while performing a decoration