### PR TITLE
feat(attribute): throw exception on incorrect use of decorator

### DIFF
--- a/Attribute/AttributeDecorator.php
+++ b/Attribute/AttributeDecorator.php
@@ -19,6 +19,9 @@ abstract class AttributeDecorator implements AttributeInterface
      **/
     public function __construct(AttributeInterface $attribute)
     {
+        if ($attribute instanceof SpecializedAttributeInterface) {
+            throw new \Exception('Use SpecializedDecorators when decorating specialized attributes');
+        }
         $this->attribute = $attribute;
     }
 


### PR DESCRIPTION
The purpose of this change is to allow me to better catch misuse of existing decorators to allow me to significantly simplify existing code, by removing code that checks for use of decorators (this code can be found all over the place).