### PR TITLE
feat(terms): Apply wildcard modifiers to search suggest term

### DIFF
--- a/Terms/SolrRegexTermsService.php
+++ b/Terms/SolrRegexTermsService.php
@@ -24,10 +24,9 @@ class SolrRegexTermsService extends AbstractSolrTermsService implements TermsSer
             return new EmptyTermsResult();
         }
 
-        $suggestQuery
-            ->setFields($field)
-            ->setRegex($query->getSearchTerm())
-            ->setSort('count');
+        $suggestQuery->setFields($field);
+        $suggestQuery->setRegex(sprintf('.*%s.*', preg_quote($query->getSearchTerm())));
+        $suggestQuery->setSort('count');
 
         try {
             $resultSet = $this->solarium->terms($suggestQuery);

--- a/Tests/Terms/SolrRegexTermsServiceTest.php
+++ b/Tests/Terms/SolrRegexTermsServiceTest.php
@@ -2,12 +2,22 @@
 
 namespace Markup\NeedleBundle\Tests\Terms;
 
+use Markup\NeedleBundle\Query\SimpleQueryInterface;
+use Markup\NeedleBundle\Terms\EmptyTermsResult;
 use Markup\NeedleBundle\Terms\SolrRegexTermsService;
+use Markup\NeedleBundle\Terms\SolrTermsResult;
 use Markup\NeedleBundle\Terms\TermsFieldProviderInterface;
 use Mockery as m;
+use Solarium\Exception\HttpException as SolariumException;
+use Solarium\QueryType\Terms\Query;
+use Solarium\QueryType\Terms\Result;
 
 class SolrRegexTermsServiceTest extends \PHPUnit_Framework_TestCase
 {
+    private $solarium;
+    private $fieldProvider;
+    private $terms;
+
     protected function setUp()
     {
         $this->solarium = m::mock('Solarium\Client');
@@ -23,5 +33,93 @@ class SolrRegexTermsServiceTest extends \PHPUnit_Framework_TestCase
     public function testIsTermsService()
     {
         $this->assertInstanceOf('Markup\NeedleBundle\Terms\TermsServiceInterface', $this->terms);
+    }
+
+    public function testFetchTermsWhenNoFieldsReturned()
+    {
+        $query = m::mock(SimpleQueryInterface::class);
+
+        $this->solarium->shouldReceive('createTerms')->once();
+        $this->fieldProvider->shouldReceive('getField')->once();
+
+        $result = $this->terms->fetchTerms($query);
+
+        $this->assertInstanceOf(EmptyTermsResult::class, $result);
+    }
+
+    public function testFetchTermsReturnsTermsResult()
+    {
+        $field = 'field';
+        $term = 'search';
+        $wildcardTerm = '.*search.*';
+
+        $query = m::mock(SimpleQueryInterface::class);
+        $query->shouldReceive('getSearchTerm')->andReturn($term);
+
+        $suggestQuery = m::mock(Query::class);
+        $suggestQuery->shouldReceive('setFields')->with($field);
+        $suggestQuery->shouldReceive('setRegex')->with($wildcardTerm);
+        $suggestQuery->shouldReceive('setSort')->with('count');
+
+        $termsResult = m::mock(Result::class);
+
+        $this->solarium->shouldReceive('createTerms')->andReturn($suggestQuery);
+        $this->solarium->shouldReceive('terms')->with($suggestQuery)
+            ->andReturn($termsResult);
+        $this->fieldProvider->shouldReceive('getField')->andReturn($field);
+
+        $result = $this->terms->fetchTerms($query);
+
+        $this->assertInstanceOf(SolrTermsResult::class, $result);
+    }
+
+    public function testFetchTermsReturnsTermsResultEscapesLuceneChars()
+    {
+        $field = 'field';
+        $term = 'search[';
+        $escapedTerm = '.*search\[.*';
+
+        $query = m::mock(SimpleQueryInterface::class);
+        $query->shouldReceive('getSearchTerm')->andReturn($term);
+
+        $suggestQuery = m::mock(Query::class);
+        $suggestQuery->shouldReceive('setFields')->with($field);
+        $suggestQuery->shouldReceive('setRegex')->with($escapedTerm);
+        $suggestQuery->shouldReceive('setSort')->with('count');
+
+        $termsResult = m::mock(Result::class);
+
+        $this->solarium->shouldReceive('createTerms')->andReturn($suggestQuery);
+        $this->solarium->shouldReceive('terms')->with($suggestQuery)
+            ->andReturn($termsResult);
+        $this->fieldProvider->shouldReceive('getField')->andReturn($field);
+
+        $result = $this->terms->fetchTerms($query);
+
+        $this->assertInstanceOf(SolrTermsResult::class, $result);
+    }
+
+    public function testFetchTermsReturnsEmptyTermsResultWhenException()
+    {
+        $field = 'field';
+        $term = 'search';
+        $wildcardTerm = '.*search.*';
+
+        $query = m::mock(SimpleQueryInterface::class);
+        $query->shouldReceive('getSearchTerm')->andReturn($term);
+
+        $suggestQuery = m::mock(Query::class);
+        $suggestQuery->shouldReceive('setFields')->with($field);
+        $suggestQuery->shouldReceive('setRegex')->with($wildcardTerm);
+        $suggestQuery->shouldReceive('setSort')->with('count');
+
+        $this->solarium->shouldReceive('createTerms')->andReturn($suggestQuery);
+        $this->solarium->shouldReceive('terms')->with($suggestQuery)
+            ->andThrow(SolariumException::class);
+        $this->fieldProvider->shouldReceive('getField')->andReturn($field);
+
+        $result = $this->terms->fetchTerms($query);
+
+        $this->assertInstanceOf(EmptyTermsResult::class, $result);
     }
 }


### PR DESCRIPTION
This may break BC if consumers are applying their wildcards to the search term. This allows us to ensure the regex is correct escaped.