### PR TITLE
fix: Correctly set page values on PagerFanta results

### DIFF
--- a/Service/SolrSearchService.php
+++ b/Service/SolrSearchService.php
@@ -139,8 +139,8 @@ class SolrSearchService implements AsyncSearchServiceInterface
                 }
 
                 $pagerfanta = new Pagerfanta(new SolariumResultPromisePagerfantaAdapter(promise_for($solariumResult)));
-                $pagerfanta->setCurrentPage($page ?: 1);
                 $pagerfanta->setMaxPerPage($maxPerPage ?: self::INFINITY);
+                $pagerfanta->setCurrentPage($page ?: 1);
 
                 $result = new PagerfantaResultAdapter($pagerfanta);
 


### PR DESCRIPTION
The current order causes issues when `$maxPerPage` is less than 10 (the default). For example:

```
$totalResults = 14;
$maxPerPage = 4;
$page = 3;
```
When the pagerFanta is created on line 141 it defaults to `$maxPerPage = 10`, so `$pagerFanta->serCurrentPage(3)` causes an error, as for `$maxPerPage = 10` the highest possible page value is 2, which should be valid for our _actual_ `$maxPerPage` value of 4.

Switching thee lines around stops this being an issue. 