### PR TITLE
refactor: add a DecorateContextTrait

### DIFF
--- a/Context/DecorateContextTrait.php
+++ b/Context/DecorateContextTrait.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Markup\NeedleBundle\Context;
+
+use Markup\NeedleBundle\Attribute\AttributeInterface;
+use Markup\NeedleBundle\Query\SelectQueryInterface;
+
+/**
+ * A trait providing template (i.e. following template pattern) methods/ instance variable for an implementation of a decorated context.
+ */
+trait DecorateContextTrait
+{
+    /**
+     * @var SearchContextInterface
+     */
+    private $context;
+
+    /**
+     * Gets the number of items that should be shown per page in a paged view.  Returns null if no constraint on numbers exists.
+     *
+     * @return int|null
+     **/
+    public function getItemsPerPage()
+    {
+        return $this->context->getItemsPerPage();
+    }
+
+    /**
+     * Gets the set of facets to apply to the search.
+     *
+     * @return \Markup\NeedleBundle\Attribute\AttributeInterface[]
+     **/
+    public function getFacets()
+    {
+        return $this->context->getFacets();
+    }
+
+    /**
+     * Gets the default filters to be applied to any search with this context.
+     *
+     * @return \Markup\NeedleBundle\Filter\FilterQueryInterface[]
+     **/
+    public function getDefaultFilterQueries()
+    {
+        return $this->context->getDefaultFilterQueries();
+    }
+
+    /**
+     * Gets the default sort collection to be applied to a query using this context.
+     *
+     * @param SelectQueryInterface $query
+     *
+     * @return \Markup\NeedleBundle\Sort\SortCollectionInterface
+     **/
+    public function getDefaultSortCollectionForQuery(SelectQueryInterface $query)
+    {
+        return $this->context->getDefaultSortCollectionForQuery($query);
+    }
+
+    /**
+     * Gets the facet set decorator to apply for a specific facet. (This can determine how a facet set renders.) Returns null if no decoration to be applied.
+     *
+     * @param  AttributeInterface                                         $facet
+     * @return \Markup\NeedleBundle\Facet\FacetSetDecoratorInterface|null
+     **/
+    public function getSetDecoratorForFacet(AttributeInterface $facet)
+    {
+        return $this->context->getSetDecoratorForFacet($facet);
+    }
+
+    /**
+     * Gets whether the given facet that is being displayed should ignore any corresponding filter values that are currently selected (true), or whether they should just reflect the returned results (false).
+     *
+     * @param  AttributeInterface $facet
+     * @return bool
+     **/
+    public function getWhetherFacetIgnoresCurrentFilters(AttributeInterface $facet)
+    {
+        return $this->context->getWhetherFacetIgnoresCurrentFilters($facet);
+    }
+
+    /**
+     * Gets a list of available filter names that a userland query using this context can filter on.
+     *
+     * @return array
+     **/
+    public function getAvailableFilterNames()
+    {
+        return $this->context->getAvailableFilterNames();
+    }
+
+    /**
+     * Gets the set of boost query fields that should be defined against this query.
+     *
+     * @return array
+     **/
+    public function getBoostQueryFields()
+    {
+        return $this->context->getBoostQueryFields();
+    }
+
+    /**
+     * Gets a provider object for collator (sorter) objects that can collate facet values.  May return null if no userland sorting of values should be done.
+     *
+     * @return \Markup\NeedleBundle\Collator\CollatorProviderInterface
+     **/
+    public function getFacetCollatorProvider()
+    {
+        return $this->context->getFacetCollatorProvider();
+    }
+
+    /**
+     * Gets a signifier for the sort order to use for sorting of facet values within the search engine itself (i.e. not within the web application).
+     *
+     * @return \Markup\NeedleBundle\Facet\SortOrderProviderInterface
+     **/
+    public function getFacetSortOrderProvider()
+    {
+        return $this->context->getFacetSortOrderProvider();
+    }
+
+    /**
+     * Gets an interceptor object that can intercept a lookup on a backend and provide redirects to specific places.
+     *
+     * @return \Markup\NeedleBundle\Intercept\InterceptorInterface
+     **/
+    public function getInterceptor()
+    {
+        return $this->context->getInterceptor();
+    }
+
+    /**
+     * Gets whether a query should request facet values for missing (i.e. no match on that facet)
+     *
+     * @return boolean
+     **/
+    public function shouldRequestFacetValueForMissing()
+    {
+        return $this->context->shouldRequestFacetValueForMissing();
+    }
+}

--- a/Context/RemoveDefaultFilterQueriesContextDecorator.php
+++ b/Context/RemoveDefaultFilterQueriesContextDecorator.php
@@ -10,19 +10,16 @@ use Markup\NeedleBundle\Query\SelectQueryInterface;
  */
 class RemoveDefaultFilterQueriesContextDecorator implements SearchContextInterface
 {
-    const LARGE_NUMBER = 10000;
+    use DecorateContextTrait;
 
-    /**
-     * @var SearchContextInterface
-     **/
-    private $searchContext;
+    const LARGE_NUMBER = 10000;
 
     /**
      * @param SearchContextInterface $searchContext The search context being decorated.
      **/
     public function __construct(SearchContextInterface $searchContext)
     {
-        $this->searchContext = $searchContext;
+        $this->context = $searchContext;
     }
 
     /**
@@ -36,88 +33,8 @@ class RemoveDefaultFilterQueriesContextDecorator implements SearchContextInterfa
     /**
      * {@inheritdoc}
      */
-    public function getDefaultSortCollectionForQuery(SelectQueryInterface $query)
-    {
-        return $this->searchContext->getDefaultSortCollectionForQuery($query);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getItemsPerPage()
     {
         return self::LARGE_NUMBER;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFacets()
-    {
-        return $this->searchContext->getFacets();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSetDecoratorForFacet(AttributeInterface $facet)
-    {
-        return $this->searchContext->getSetDecoratorForFacet($facet);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getWhetherFacetIgnoresCurrentFilters(AttributeInterface $facet)
-    {
-        return $this->searchContext->getWhetherFacetIgnoresCurrentFilters($facet);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getAvailableFilterNames()
-    {
-        return $this->searchContext->getAvailableFilterNames();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getBoostQueryFields()
-    {
-        return $this->searchContext->getBoostQueryFields();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFacetCollatorProvider()
-    {
-        return $this->searchContext->getFacetCollatorProvider();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFacetSortOrderProvider()
-    {
-        return $this->searchContext->getFacetSortOrderProvider();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getInterceptor()
-    {
-        return $this->searchContext->getInterceptor();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function shouldRequestFacetValueForMissing()
-    {
-        return $this->searchContext->shouldRequestFacetValueForMissing();
     }
 }

--- a/Context/UseAvailableFiltersAsFacetsContextDecorator.php
+++ b/Context/UseAvailableFiltersAsFacetsContextDecorator.php
@@ -11,27 +11,18 @@ use Markup\NeedleBundle\Query\SelectQueryInterface;
  */
 class UseAvailableFiltersAsFacetsContextDecorator implements SearchContextInterface
 {
-    /**
-     * The context being decorated.
-     *
-     * @var SearchContextInterface
-     **/
-    private $searchContext;
+    use DecorateContextTrait;
 
     /**
      * @var FacetProviderInterface
      **/
     private $facetProvider;
 
-    /**
-     * @param SearchContextInterface $searchContext
-     * @param FacetProviderInterface $facetProvider
-     **/
     public function __construct(
         SearchContextInterface $searchContext,
         FacetProviderInterface $facetProvider
     ) {
-        $this->searchContext = $searchContext;
+        $this->context = $searchContext;
         $this->facetProvider = $facetProvider;
     }
 
@@ -46,93 +37,5 @@ class UseAvailableFiltersAsFacetsContextDecorator implements SearchContextInterf
         }
 
         return $facets;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getItemsPerPage()
-    {
-        return $this->searchContext->getItemsPerPage();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultFilterQueries()
-    {
-        return $this->searchContext->getDefaultFilterQueries();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultSortCollectionForQuery(SelectQueryInterface $query)
-    {
-        return $this->searchContext->getDefaultSortCollectionForQuery($query);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSetDecoratorForFacet(AttributeInterface $facet)
-    {
-        return $this->searchContext->getSetDecoratorForFacet($facet);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getWhetherFacetIgnoresCurrentFilters(AttributeInterface $facet)
-    {
-        return $this->searchContext->getWhetherFacetIgnoresCurrentFilters($facet);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getAvailableFilterNames()
-    {
-        return $this->searchContext->getAvailableFilterNames();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getBoostQueryFields()
-    {
-        return $this->searchContext->getBoostQueryFields();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFacetCollatorProvider()
-    {
-        return $this->searchContext->getFacetCollatorProvider();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFacetSortOrderProvider()
-    {
-        return $this->searchContext->getFacetSortOrderProvider();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getInterceptor()
-    {
-        return $this->searchContext->getInterceptor();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function shouldRequestFacetValueForMissing()
-    {
-        return $this->searchContext->shouldRequestFacetValueForMissing();
     }
 }

--- a/Tests/Context/DecorateContextTraitTest.php
+++ b/Tests/Context/DecorateContextTraitTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Markup\NeedleBundle\Tests\Context;
+
+use Markup\NeedleBundle\Context\DecorateContextTrait;
+use Markup\NeedleBundle\Context\SearchContextInterface;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class DecorateContextTraitTest extends MockeryTestCase
+{
+    /**
+     * @var SearchContextInterface|m\MockInterface
+     */
+    private $decorated;
+
+    /**
+     * @var SearchContextInterface
+     */
+    private $context;
+
+    protected function setUp()
+    {
+        $this->decorated = m::spy(SearchContextInterface::class);
+        $decorated = $this->decorated;
+        $this->context = new class ($decorated) implements SearchContextInterface {
+            use DecorateContextTrait;
+
+            public function __construct(SearchContextInterface $context)
+            {
+                $this->context = $context;
+            }
+        };
+    }
+
+    public function testPublicMethodsDelegateDown()
+    {
+        $reflection = new \ReflectionObject($this->context);
+        foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $publicMethod) {
+            if ($publicMethod->getName() === '__construct') {
+                continue;
+            }
+            $thing = 'a thing';
+            $mockedArgs = $this->getMockedArgsForMethod($publicMethod);
+            $this->decorated
+                ->shouldReceive($publicMethod->getName())
+                ->withArgs($mockedArgs)
+                ->andReturn($thing);
+            $this->assertSame($thing, $this->context->{$publicMethod->getName()}(...$mockedArgs));
+        }
+    }
+
+    private function getMockedArgsForMethod(\ReflectionMethod $method): array
+    {
+        return array_map(
+            function (\ReflectionParameter $param) {
+                //this works because only method params for this interface are typed objects
+                return m::mock($param->getType()->getName());
+            },
+            $method->getParameters()
+        );
+    }
+}


### PR DESCRIPTION
The purpose of this is to remove boilerplate from individual decorator implementations, and also to insulate classes using this trait from being broken if the search context interface is extended.