### PR TITLE
feat: (breaking change) allow configuration of search context to specify use of fuzzy matching

### DIFF
--- a/Config/ContextConfiguration.php
+++ b/Config/ContextConfiguration.php
@@ -15,7 +15,7 @@ class ContextConfiguration implements ContextConfigurationInterface
      * A hash containing all the configuration passed in. Keys are:
      *
      * items_per_page, base_filter_queries, sorts, sorts_search_term, sorts_non_search_term, boosts,
-     * filters, facets, intercepts, should_ignore_current_filters_in_faceting
+     * filters, facets, intercepts, should_ignore_current_filters_in_faceting, should_use_fuzzy_matching
      *
      * Values are exactly in the format as the various methods should return.
      */
@@ -152,6 +152,11 @@ class ContextConfiguration implements ContextConfigurationInterface
         return (bool) $this->config['should_ignore_current_filters_in_faceting'];
     }
 
+    public function shouldUseFuzzyMatching()
+    {
+        return (bool) $this->config['should_use_fuzzy_matching'];
+    }
+
     /**
      * @return array
      */
@@ -165,6 +170,7 @@ class ContextConfiguration implements ContextConfigurationInterface
             'facets' => [],
             'intercepts' => [],
             'should_ignore_current_filters_in_faceting' => false,
+            'should_use_fuzzy_matching' => false,
         ];
     }
 }

--- a/Config/ContextConfigurationInterface.php
+++ b/Config/ContextConfigurationInterface.php
@@ -93,4 +93,11 @@ interface ContextConfigurationInterface
      * @return bool
      */
     public function shouldIgnoreCurrentFilteredAttributesInFaceting();
-}
+
+    /**
+     * Gets whether this context configuration suggests that queries should use fuzzy matching on search terms where applicable.
+     *
+     * @return bool
+     */
+    public function shouldUseFuzzyMatching();
+} 

--- a/Context/ConfiguredContext.php
+++ b/Context/ConfiguredContext.php
@@ -261,4 +261,9 @@ class ConfiguredContext implements SearchContextInterface
     {
         return false;
     }
+
+    public function shouldUseFuzzyMatching()
+    {
+        return $this->config->shouldUseFuzzyMatching();
+    }
 }

--- a/Context/DecorateContextTrait.php
+++ b/Context/DecorateContextTrait.php
@@ -138,4 +138,9 @@ trait DecorateContextTrait
     {
         return $this->context->shouldRequestFacetValueForMissing();
     }
+
+    public function shouldUseFuzzyMatching()
+    {
+        return $this->context->shouldUseFuzzyMatching();
+    }
 }

--- a/Context/SearchContext.php
+++ b/Context/SearchContext.php
@@ -126,4 +126,9 @@ class SearchContext implements SearchContextInterface
     {
         return false;
     }
+
+    public function shouldUseFuzzyMatching()
+    {
+        return false;
+    }
 }

--- a/Context/SearchContextInterface.php
+++ b/Context/SearchContextInterface.php
@@ -94,7 +94,14 @@ interface SearchContextInterface
     /**
      * Gets whether a query should request facet values for missing (i.e. no match on that facet)
      *
-     * @return boolean
+     * @return bool
      **/
     public function shouldRequestFacetValueForMissing();
+
+    /**
+     * Gets whether a search backend using this context should use fuzzy matching on search terms if this functionality is available.
+     *
+     * @return bool
+     */
+    public function shouldUseFuzzyMatching();
 }

--- a/Tests/Config/ContextConfigurationTest.php
+++ b/Tests/Config/ContextConfigurationTest.php
@@ -75,19 +75,19 @@ class ContextConfigurationTest extends TestCase
 
     public function testFullConfigGivesItemsPerPage()
     {
-        $config = new ContextConfiguration($this->getFullConfiguration());
+        $config = $this->createFullConfig();
         $this->assertEquals(12, $config->getDefaultItemsPerPage());
     }
 
     public function testFullConfigGivesDefaultFilterQueries()
     {
-        $config = new ContextConfiguration($this->getFullConfiguration());
+        $config = $this->createFullConfig();
         $this->assertEquals(['active' => true, 'in_stock' => true], $config->getDefaultFilterQueries());
     }
 
     public function testFullConfigGivesSortsForSearchTermsFromFallback()
     {
-        $config = new ContextConfiguration($this->getFullConfiguration());
+        $config = $this->createFullConfig();
         $this->assertEquals(
             ['name' => ContextConfigurationInterface::ORDER_ASC, 'price' => ContextConfigurationInterface::ORDER_DESC],
             $config->getDefaultSortsForSearchTermQuery()
@@ -96,7 +96,7 @@ class ContextConfigurationTest extends TestCase
 
     public function testFullConfigGivesSortsForNonSearchTerm()
     {
-        $config = new ContextConfiguration($this->getFullConfiguration());
+        $config = $this->createFullConfig();
         $this->assertEquals(
             ['velocity' => ContextConfigurationInterface::ORDER_DESC],
             $config->getDefaultSortsForNonSearchTermQuery()
@@ -105,19 +105,19 @@ class ContextConfigurationTest extends TestCase
 
     public function testFullConfigGivesBoosts()
     {
-        $config = new ContextConfiguration($this->getFullConfiguration());
+        $config = $this->createFullConfig();
         $this->assertEquals(['name' => 5, 'category' => 0.4], $config->getDefaultBoosts());
     }
 
     public function testFullConfigGivesFacets()
     {
-        $config = new ContextConfiguration($this->getFullConfiguration());
+        $config = $this->createFullConfig();
         $this->assertEquals(['gender', 'category', 'price'], $config->getDefaultFacetingAttributes());
     }
 
     public function testFullConfigGivesIntercepts()
     {
-        $config = new ContextConfiguration($this->getFullConfiguration());
+        $config = $this->createFullConfig();
         $this->assertEquals(
             [
                 'sale' => [
@@ -140,14 +140,20 @@ class ContextConfigurationTest extends TestCase
 
     public function testFullConfigGivesFilterableAttributes()
     {
-        $config = new ContextConfiguration($this->getFullConfiguration());
+        $config = $this->createFullConfig();
         $this->assertEquals(['gender', 'color', 'size', 'on_sale'], $config->getFilterableAttributes());
     }
 
     public function testFullConfigGivesShouldIgnoreCurrentFiltersInFaceting()
     {
-        $config = new ContextConfiguration($this->getFullConfiguration());
+        $config = $this->createFullConfig();
         $this->assertTrue($config->shouldIgnoreCurrentFilteredAttributesInFaceting());
+    }
+
+    public function testFullConfigGivesShouldUseFuzzyMatching()
+    {
+        $config = $this->createFullConfig();
+        $this->assertTrue($config->shouldUseFuzzyMatching());
     }
 
     /**
@@ -179,6 +185,12 @@ class ContextConfigurationTest extends TestCase
             ],
             'filters' => ['gender', 'color', 'size', 'on_sale'],
             'should_ignore_current_filters_in_faceting' => true,
+            'should_use_fuzzy_matching' => true,
         ];
+    }
+
+    private function createFullConfig(): ContextConfiguration
+    {
+        return new ContextConfiguration($this->getFullConfiguration());
     }
 }

--- a/Tests/Context/ConfiguredContextTest.php
+++ b/Tests/Context/ConfiguredContextTest.php
@@ -24,6 +24,16 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class ConfiguredContextTest extends MockeryTestCase
 {
+    /**
+     * @var ContextConfigurationInterface|m\MockInterface
+     */
+    private $config;
+
+    /**
+     * @var ConfiguredContext
+     */
+    private $context;
+
     protected function setUp()
     {
         $this->config = m::mock(ContextConfigurationInterface::class);
@@ -275,5 +285,14 @@ class ConfiguredContextTest extends MockeryTestCase
             ->shouldReceive('getIntercepts')
             ->andReturn($config);
         $this->assertSame($interceptor, $this->context->getInterceptor());
+    }
+
+    public function testShouldUseFuzzyMatching()
+    {
+        $shouldMatch = true;
+        $this->config
+            ->shouldReceive('shouldUseFuzzyMatching')
+            ->andReturn($shouldMatch);
+        $this->assertEquals($shouldMatch, $this->context->shouldUseFuzzyMatching());
     }
 }

--- a/Tests/Context/SearchContextInterfaceTest.php
+++ b/Tests/Context/SearchContextInterfaceTest.php
@@ -2,6 +2,7 @@
 
 namespace Markup\NeedleBundle\Tests\Context;
 
+use Markup\NeedleBundle\Context\SearchContextInterface;
 use Markup\NeedleBundle\Tests\AbstractInterfaceTestCase;
 
 /**
@@ -24,11 +25,12 @@ class SearchContextInterfaceTest extends AbstractInterfaceTestCase
             'getFacetSortOrderProvider',
             'getInterceptor',
             'shouldRequestFacetValueForMissing',
+            'shouldUseFuzzyMatching',
         ];
     }
 
     protected function getInterfaceUnderTest()
     {
-        return 'Markup\NeedleBundle\Context\SearchContextInterface';
+        return SearchContextInterface::class;
     }
 }


### PR DESCRIPTION
NB. This does not (yet) implement fuzzy matching with any search backends - however, it does allow the intent to use fuzzy matching to be signalled in a search context.

The reason for putting it in the search context is electing to use fuzzy matching is unlikely to be universal for an application - it depends on the context being used.

However, this PR is for the acceptance of the extension of the search context in principle.