### PR TITLE
fix: Add delete queries to corpus indexing

### DIFF
--- a/Indexer/CorpusIndexingCommand.php
+++ b/Indexer/CorpusIndexingCommand.php
@@ -159,7 +159,7 @@ class CorpusIndexingCommand
         $subjects = $wrappingIterator;
         $updateQuery = $this->getSolariumClient()->createUpdate();
         //initially delete all indexes - todo allow disambiguation between types of document
-        if ($this->shouldPreDelete) {
+        if ($this->shouldPreDelete || !is_null($this->deleteQuery)) {
             $updateQuery->addDeleteQuery($this->getDeleteQueryLucene());
         }
         $documentGenerator = new SubjectDocumentGenerator($this->getSubjectMapper(), $this->shouldAllowNullFieldValues);


### PR DESCRIPTION
Setting delete queries on the corpus indexing command currently doesn't appear to be working. Seems to be multiple issues here:

1) The delete queries are only added to the command when a full delete is set. In reality this would cause a full delete to be requested, but only the delete query set to be ran.
2) Setting these delete queries doesn't appear to actually delete the entries from solr.

First commit here addresses the first issue - separating the full deletions from the more focussed delete queries. Will continue to look into the second issue and add to this PR.