### PR TITLE
fix: declare static dictionary provider class as abstract

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -110,6 +110,7 @@ services:
         class: Markup\NeedleBundle\Query\NullHandlerProvider
     markup_needle.spellcheck.static_dictionary_provider:
         class: Markup\NeedleBundle\Spellcheck\StaticDictionaryProvider
+        abstract: true
     markup_needle.spellcheck.dictionary_provider.default:
         parent: markup_needle.spellcheck.static_dictionary_provider
         arguments:


### PR DESCRIPTION
Fixing an illegal service definition (the arguments for it have not been declared).