### PR TITLE
build: drop low build (failing due to composer ∞ loop and add php 7.4 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ php:
     - 7.1.19
     - 7.2.7
     - 7.3
+    - 7.4
 
 env:
     global:
         - deps=high
 
 install:
-    - if [ "$deps" = "high" ]; then composer install --ignore-platform-reqs; fi;
-    - if [ "$deps" = "low" ]; then composer --prefer-lowest --prefer-stable --ignore-platform-reqs update; fi
+    - composer install --ignore-platform-reqs
 
 before_script:
     - if [ -f $HOME/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini ]; then phpenv config-rm xdebug.ini; fi
@@ -22,11 +22,6 @@ script:
 
 notifications:
   email: "douglas@usemarkup.com"
-
-matrix:
-  include:
-    - php: 7.1.19
-      env: deps=low
 
 sudo: required
 dist: xenial


### PR DESCRIPTION
The low build was causing a composer infinite loop, which may have something to do with cached dependencies, but considering PHP 7.1 is likely to be dropped soon it seemed to make sense to drop this low build for the sake of the other passing environments. Adding PHP 7.4 builds too.