### PR TITLE
feat(query): splits base, default and applied queries for better facet function

### DIFF
--- a/Query/ResolvedSelectQuery.php
+++ b/Query/ResolvedSelectQuery.php
@@ -4,21 +4,22 @@ namespace Markup\NeedleBundle\Query;
 
 use Markup\NeedleBundle\Attribute\AttributeInterface;
 use Markup\NeedleBundle\Boost\BoostQueryField;
+use Markup\NeedleBundle\Builder\DedupeFilterQueryTrait;
 use Markup\NeedleBundle\Collator\CollatorProviderInterface;
-use Markup\NeedleBundle\Collator\NullCollatorProvider;
 use Markup\NeedleBundle\Context\NoopSearchContext;
-use Markup\NeedleBundle\Context\SearchContext;
 use Markup\NeedleBundle\Context\SearchContextInterface;
 use Markup\NeedleBundle\Facet\FacetSetDecoratorProviderInterface;
 use Markup\NeedleBundle\Filter\FilterQueryInterface;
-use Markup\NeedleBundle\Sort\EmptySortCollection;
 use Markup\NeedleBundle\Sort\SortCollectionInterface;
 
 /**
+ *
  * {@inheritdoc}
  */
 class ResolvedSelectQuery implements ResolvedSelectQueryInterface
 {
+    use DedupeFilterQueryTrait;
+
     /**
      * @var SelectQueryInterface
      */
@@ -56,9 +57,45 @@ class ResolvedSelectQuery implements ResolvedSelectQueryInterface
      */
     public function getFilterQueries(): array
     {
-        $fq = $this->getSelectQuery()->getFilterQueries();
+        return $this->dedupeFilterQueries(array_merge(
+            $this->getSelectQuery()->getFilterQueries(),
+            $this->searchContext->getDefaultFilterQueries()
+        ));
+    }
 
-        return array_merge($fq, $this->searchContext->getDefaultFilterQueries());
+    /**
+     * {@inheritdoc}
+     */
+    public function getContextFilterQueries(): array
+    {
+        return $this->searchContext->getDefaultFilterQueries();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaseFilterQueries(): array
+    {
+        return $this->getSelectQuery()->getBaseFilterQueries();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaseAndContextFilterQueries(): array
+    {
+        return $this->dedupeFilterQueries(array_merge(
+            $this->searchContext->getDefaultFilterQueries(),
+            $this->getSelectQuery()->getBaseFilterQueries()
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAppliedFilterQueries(): array
+    {
+        return $this->getSelectQuery()->getAppliedFilterQueries();
     }
 
     /**

--- a/Query/ResolvedSelectQueryInterface.php
+++ b/Query/ResolvedSelectQueryInterface.php
@@ -16,6 +16,10 @@ use Markup\NeedleBundle\Sort\SortCollectionInterface;
  *
  * This structure represents a more accurate version of the actual query that is executed against the search backend
  * than the Query alone
+ *
+ * 2020: The value of this abstraction is now not clear. It provides a way to access the search context and the search
+ * query at the same time, but in all probability this is obfuscation and makes things more confusing. This looks
+ * like a candidate to be removed IMO.
  */
 interface ResolvedSelectQueryInterface
 {
@@ -30,6 +34,26 @@ interface ResolvedSelectQueryInterface
      * @return array|FilterQueryInterface[]
      */
     public function getFilterQueries(): array;
+
+    /**
+     * @return array|FilterQueryInterface[]
+     */
+    public function getContextFilterQueries(): array;
+
+    /**
+     * @return array|FilterQueryInterface[]
+     */
+    public function getBaseFilterQueries(): array;
+
+    /**
+     * @return array|FilterQueryInterface[]
+     */
+    public function getBaseAndContextFilterQueries(): array;
+
+    /**
+     * @return array|FilterQueryInterface[]
+     */
+    public function getAppliedFilterQueries(): array;
 
     /**
      * @return array|AttributeInterface[]

--- a/Query/SelectQuery.php
+++ b/Query/SelectQuery.php
@@ -17,11 +17,6 @@ class SelectQuery implements SelectQueryInterface
     /**
      * @var array
      */
-    private $filterQueries;
-
-    /**
-     * @var array
-     */
     private $fields;
 
     /**
@@ -69,8 +64,19 @@ class SelectQuery implements SelectQueryInterface
      */
     private $facets;
 
+    /**
+     * @var array
+     */
+    private $baseFilterQueries;
+
+    /**
+     * @var array
+     */
+    private $appliedFilterQueries;
+
     public function __construct(
-        array $filterQueries,
+        array $baseFilterQueries,
+        array $appliedFilterQueries,
         array $fields,
         ?array $facets = null,
         ?int $pageNumber = null,
@@ -82,7 +88,6 @@ class SelectQuery implements SelectQueryInterface
         ?SortCollectionInterface $groupingSortCollection = null,
         bool $shouldTreatAsTextSearch = false
     ) {
-        $this->filterQueries = $filterQueries;
         $this->facets = $facets;
         $this->fields = $fields;
         $this->pageNumber = $pageNumber;
@@ -93,6 +98,8 @@ class SelectQuery implements SelectQueryInterface
         $this->groupingSortCollection = $groupingSortCollection;
         $this->shouldTreatAsTextSearch = $shouldTreatAsTextSearch;
         $this->searchTerm = $searchTerm;
+        $this->baseFilterQueries = $baseFilterQueries;
+        $this->appliedFilterQueries = $appliedFilterQueries;
     }
 
     /**
@@ -100,7 +107,7 @@ class SelectQuery implements SelectQueryInterface
      */
     public function getFilterQueries(): array
     {
-        return $this->filterQueries;
+        return array_merge($this->baseFilterQueries, $this->appliedFilterQueries);
     }
 
     /**
@@ -108,7 +115,7 @@ class SelectQuery implements SelectQueryInterface
      */
     public function hasFilterQueries(): bool
     {
-        return count($this->filterQueries) > 0;
+        return count($this->getFilterQueries()) > 0;
     }
 
     /**
@@ -165,7 +172,7 @@ class SelectQuery implements SelectQueryInterface
      */
     public function getFilterQueryWithKey(string $key): ?FilterQueryInterface
     {
-        foreach ($this->filterQueries as $filterQuery) {
+        foreach ($this->getFilterQueries() as $filterQuery) {
             if (!$filterQuery instanceof FilterQueryInterface) {
                 continue;
             }
@@ -267,5 +274,15 @@ class SelectQuery implements SelectQueryInterface
     public function hasFacets(): bool
     {
         return $this->facets !== null;
+    }
+
+    public function getBaseFilterQueries(): array
+    {
+        return $this->baseFilterQueries;
+    }
+
+    public function getAppliedFilterQueries(): array
+    {
+        return $this->appliedFilterQueries;
     }
 }

--- a/Query/SelectQueryInterface.php
+++ b/Query/SelectQueryInterface.php
@@ -12,7 +12,14 @@ use Markup\NeedleBundle\Spellcheck\SpellcheckInterface;
  **/
 interface SelectQueryInterface extends SimpleQueryInterface
 {
+    // combined base filter and applied filter queries
     public function getFilterQueries(): array;
+
+    // base filters are those added in such a way that the user manipulating filters cannot get rid of them
+    public function getBaseFilterQueries(): array;
+
+    // applied filters are those chose by the user
+    public function getAppliedFilterQueries(): array;
 
     public function hasFilterQueries(): bool;
 

--- a/Tests/Builder/SolariumSelectQueryBuilderTest.php
+++ b/Tests/Builder/SolariumSelectQueryBuilderTest.php
@@ -97,7 +97,7 @@ class SolariumSelectQueryBuilderTest extends MockeryTestCase
             ->shouldReceive('getFilterValue')
             ->andReturn($filterValue);
         $genericQuery
-            ->shouldReceive('getFilterQueries')
+            ->shouldReceive('getBaseAndContextFilterQueries')
             ->andReturn([$filterQuery]);
         $query = $this->builder->buildSolariumQueryFromGeneric($genericQuery, $this->queryGenerator);
         $filterQueries = $query->getFilterQueries();


### PR DESCRIPTION
This PR fixes:
an internal ticket

A video is included on the above ticket but in effect this corrects some of the the behaviour that was removed when 'recorded queries' were stripped out.